### PR TITLE
add a remove option for cosmic altars, allowing for Aether Runes combo rune craft

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,11 +15,15 @@ repositories {
 	mavenLocal()
 	maven {
 		url = 'https://repo.runelite.net'
+		content {
+			includeGroupByRegex("net\\.runelite.*")
+		}
 	}
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.28'
+def runeLiteVersion = 'latest.release'
+def pluginMainClass = 'com.duckblade.osrs.comborunes.ComboRunesOnlyPluginTest'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -37,4 +41,38 @@ sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'
+}
+
+tasks.register('run', JavaExec) {
+	classpath = sourceSets.test.runtimeClasspath
+	mainClass = pluginMainClass
+
+	jvmArgs "-ea"
+	args "--developer-mode", "--debug"
+}
+
+tasks.register('shadowJar', Jar) {
+	dependsOn configurations.testRuntimeClasspath
+	manifest {
+		attributes('Main-Class': pluginMainClass, 'Multi-Release': true)
+	}
+
+	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+	from sourceSets.main.output
+	from sourceSets.test.output
+	from {
+		configurations.testRuntimeClasspath.collect { file ->
+			file.isDirectory() ? file : zipTree(file)
+		}
+	}
+
+	exclude 'META-INF/INDEX.LIST'
+	exclude 'META-INF/*.SF'
+	exclude 'META-INF/*.DSA'
+	exclude 'META-INF/*.RSA'
+	exclude '**/module-info.class'
+
+	group = BasePlugin.BUILD_GROUP
+	archiveClassifier.set('shadow')
+	archiveFileName.set("${rootProject.name}-${project.version}-all.jar")
 }

--- a/src/main/java/com/duckblade/osrs/comborunes/Altar.java
+++ b/src/main/java/com/duckblade/osrs/comborunes/Altar.java
@@ -12,7 +12,8 @@ public enum Altar
 	AIR(11339, ComboRunesOnlyConfig::removeAir),
 	WATER(10827, ComboRunesOnlyConfig::removeWater),
 	EARTH(10571, ComboRunesOnlyConfig::removeEarth),
-	FIRE(10315, ComboRunesOnlyConfig::removeFire);
+	FIRE(10315, ComboRunesOnlyConfig::removeFire),
+	COSMIC(8523, ComboRunesOnlyConfig::removeCosmic);
 
 	private final int region;
 	private final Function<ComboRunesOnlyConfig, Boolean> configGetter;

--- a/src/main/java/com/duckblade/osrs/comborunes/ComboRunesOnlyConfig.java
+++ b/src/main/java/com/duckblade/osrs/comborunes/ComboRunesOnlyConfig.java
@@ -56,10 +56,21 @@ public interface ComboRunesOnlyConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "removeCosmic",
+			name = "Remove for Cosmic Altar",
+			description = "Remove left-click craft-rune from the Cosmic Altar.",
+			position = 5
+	)
+	default boolean removeCosmic()
+	{
+		return true;
+	}
+
+	@ConfigItem(
 		keyName = "removeMode",
 		name = "Mode",
 		description = "Whether to deprioritize or completely remove craft-rune at altars.",
-		position = 5
+		position = 6
 	)
 	default RemoveMode removeMode()
 	{


### PR DESCRIPTION
Added a removal option for the cosmic altar, because you craft aether rune combo runes there. Also made the the build.gradle up-to-date to easily use the 'run' option. Very small fix!

https://github.com/user-attachments/assets/2bab0b99-92ba-4f90-afd2-54a4b8286c3a

